### PR TITLE
Update Group Landing Page URL and path

### DIFF
--- a/modules/osu_groups_basic_group/osu_groups_basic_group.module
+++ b/modules/osu_groups_basic_group/osu_groups_basic_group.module
@@ -22,33 +22,6 @@ function osu_groups_basic_group_form_alter(&$form, FormStateInterface $form_stat
 }
 
 /**
- * Implements hook_pathauto_alias_alter().
- */
-function osu_groups_basic_group_pathauto_alias_alter(&$alias, array &$context) {
-  if ($context['module'] === 'node') {
-    /** @var Node $node */
-    $node = $context['data']['node'];
-    $group_handler = new OsuGroupsHandler();
-    $osu_basic_group_handler = new OsuGroupsBasicGroupHandler();
-    $group_content = $group_handler->getGroupContentFromNode($node);
-    if ($group_content) {
-      /** @var \Drupal\group\Entity\Group $group */
-      $group = $group_content->getGroup();
-      /** @var Node $group_landing_node */
-      $group_landing_node = $osu_basic_group_handler->getGroupLandingNode($group);
-      // Only operate when not on group landing page.
-      if ($group_landing_node && ($group_landing_node->id() !== $node->id())) {
-        $group_landing_page_path = $group_landing_node->toUrl()->toString();
-        // If we don't start with the group path then add it, else do nothing.
-        if (substr_compare($alias, $group_landing_page_path, 0, strlen($group_landing_page_path)) !== 0) {
-          $alias = $group_landing_page_path . $alias;
-        }
-      }
-    }
-  }
-}
-
-/**
  * Implements hook_preprocess_HOOK().
  */
 function osu_groups_basic_group_preprocess_html(&$variables) {
@@ -84,6 +57,47 @@ function osu_groups_basic_group_preprocess_html(&$variables) {
       }
     }
 
+  }
+}
+
+/**
+ * Implements hook_pathauto_alias_alter().
+ */
+function osu_groups_basic_group_pathauto_alias_alter(&$alias, array &$context) {
+  if ($context['module'] === 'node') {
+    /** @var Node $node */
+    $node = $context['data']['node'];
+    $nid = $node->id();
+    $group_handler = new OsuGroupsHandler();
+    $osu_basic_group_handler = new OsuGroupsBasicGroupHandler();
+    $group_content = $group_handler->getGroupContentFromNode($node);
+    // If node is group content, node is created first, then associated to group thus updating group content.
+    if ($group_content) {
+      /** @var \Drupal\group\Entity\Group $group */
+      $group = $group_content->getGroup();
+      /** @var Node $group_landing_node */
+      $group_landing_node = $osu_basic_group_handler->getGroupLandingNode($group);
+      // Only operate when not on group landing page.
+      if ($group_landing_node && ($group_landing_node->id() !== $node->id())) {
+        $group_landing_page_path = $group_landing_node->toUrl()->toString();
+        // If we don't start with the group path then add it, else do nothing.
+        if (substr_compare($alias, $group_landing_page_path, 0, strlen($group_landing_page_path)) !== 0) {
+          /** @var \Drupal\redirect\RedirectRepository $redirects */
+          $redirects = \Drupal::service('redirect.repository')
+            ->findByDestinationUri(["internal:/node/$nid", "entity:node/$nid"]);
+          /** @var \Drupal\redirect\Entity\Redirect $redirect */
+          foreach ($redirects as $redirect) {
+            // if redirect starts with our same path and might have a -number on the end
+            // delete the redirect as we probably don't need it.
+            if (substr_compare($redirect->getSourceUrl(), $alias, 0, strlen($alias)) <= 0) {
+              redirect_delete_by_path($redirect->getSourceUrl());
+            }
+          }
+          $alias = $group_landing_page_path . $alias;
+        }
+      }
+
+    }
   }
 }
 

--- a/modules/osu_groups_basic_group/src/OsuGroupsBasicGroupSystemBrandingBlockAlter.php
+++ b/modules/osu_groups_basic_group/src/OsuGroupsBasicGroupSystemBrandingBlockAlter.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\osu_groups_basic_group;
 
-use Drupal;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Render\Element\RenderCallbackInterface;
 use Drupal\node\Entity\Node;
@@ -16,11 +15,11 @@ use Drupal\osu_groups\OsuGroupsHandler;
 class OsuGroupsBasicGroupSystemBrandingBlockAlter implements RenderCallbackInterface {
 
   /**
-   * #pre_render callback: Sets site name if node is in a group.
+   * Pre Render Callback Sets site name if node is in a group.
    */
   public static function preRender($build) {
-    $current_path = Drupal::service('path.current')->getPath();
-    $path = Drupal::service('path_alias.manager')
+    $current_path = \Drupal::service('path.current')->getPath();
+    $path = \Drupal::service('path_alias.manager')
       ->getPathByAlias($current_path);
     // Ensures Block will be cached based on URL path only.
     CacheableMetadata::createFromRenderArray($build)

--- a/modules/osu_groups_basic_group/src/OsuGroupsBasicGroupSystemBrandingBlockAlter.php
+++ b/modules/osu_groups_basic_group/src/OsuGroupsBasicGroupSystemBrandingBlockAlter.php
@@ -34,10 +34,12 @@ class OsuGroupsBasicGroupSystemBrandingBlockAlter implements RenderCallbackInter
       if ($group_content) {
         $group_name = $osu_groups->getGroupNameFromNode($node);
         $group_landing_page = $osu_groups_basic_group->getGroupLandingNode($group_content->getGroup());
-        $group_landing_page->toUrl();
-        $group_landing_page_path = $group_landing_page->toUrl()->toString();
-        $build['content']['site_name']['#markup'] = $group_name;
-        $build['content']['site_path']['#uri'] = $group_landing_page_path;
+        if (!is_null($group_landing_page)) {
+          $group_landing_page->toUrl();
+          $group_landing_page_path = $group_landing_page->toUrl()->toString();
+          $build['content']['site_name']['#markup'] = $group_name;
+          $build['content']['site_path']['#uri'] = $group_landing_page_path;
+        }
       }
     }
     return $build;


### PR DESCRIPTION
fixes an issue when creating group content and a group doesn't having landing page configured.
adds some logic to clean up an extra url redirect that gets created when creating a group page and putting that page a the top of the group menu.