### PR TITLE
Remove width and height attributes from Twitter cards

### DIFF
--- a/modules/osu_groups_basic_group/config/install/metatag.metatag_defaults.group.yml
+++ b/modules/osu_groups_basic_group/config/install/metatag.metatag_defaults.group.yml
@@ -25,7 +25,5 @@ tags:
   twitter_cards_description: '[group:field_osu_group_meta_description]'
   twitter_cards_image: '[group:field_osu_group_meta_image:entity:field_media_image:twitter_300x157]'
   twitter_cards_image_alt: '[group:field_osu_group_meta_image:entity:field_media_image:alt]'
-  twitter_cards_image_height: '[group:field_osu_group_meta_image:entity:field_media_image:twitter_300x157:height]'
-  twitter_cards_image_width: '[group:field_osu_group_meta_image:entity:field_media_image:twitter_300x157:width]'
   twitter_cards_title: '[group:title]'
   twitter_cards_type: summary_large_image


### PR DESCRIPTION
The width and height attributes for Twitter cards' images are removed from the OSU groups basic group module configuration. This action is to streamline the configuration and follow best practices for meta tags in Twitter cards.