### PR TITLE
Add redirect management to group module.

### DIFF
--- a/osu_groups.module
+++ b/osu_groups.module
@@ -9,6 +9,17 @@ use Drupal\Core\Url;
  * Most of this code was taken from the Drupal Redirect module.
  */
 function osu_groups_form_group_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Theme Form options if drupal.org/i/3441929 is closed
+  //  $form['#theme'] = ['group_edit_form'];
+  //  $form['#attached']['library'][] = 'claro/node-form';
+  //  $form['advanced']['#type'] = 'container';
+  //  $form['advanced']['#accordion'] = TRUE;
+  //  $form['meta']['#type'] = 'container';
+  //  $form['meta']['#access'] = TRUE;
+  //  $form['revision_information']['#type'] = 'container';
+  //  $form['revision_information']['#group'] = 'meta';
+  //  $form['revision_information']['#attributes']['class'][] = 'entity-meta__revision';
+
   /** @var \Drupal\group\Entity\GroupInterface $group */
   $group = $form_state->getFormObject()->getEntity();
   // Ensure that we are not on a New group and that the user has the correct permission.

--- a/osu_groups.module
+++ b/osu_groups.module
@@ -1,0 +1,97 @@
+<?php
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ *
+ * Most of this code was taken from the Drupal Redirect module.
+ */
+function osu_groups_form_group_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  /** @var \Drupal\group\Entity\GroupInterface $group */
+  $group = $form_state->getFormObject()->getEntity();
+  // Ensure that we are not on a New group and that the user has the correct permission.
+  if (!$group->isNew() && \Drupal::currentUser()
+      ->hasPermission('administer redirects')) {
+    $gid = $group->id();
+    // Find redirects to this group.
+    $redirects = \Drupal::service('redirect.repository')
+      ->findByDestinationUri(["internal:/group/$gid", "entity:group/$gid"]);
+    // Assemble the rows for the table.
+
+    $rows = [];
+    /** @var \Drupal\Core\Entity\EntityListBuilder $list_builder */
+    $list_builder = \Drupal::service('entity_type.manager')
+      ->getListBuilder('redirect');
+    /** @var \Drupal\redirect\Entity\Redirect[] $redirects */
+    foreach ($redirects as $redirect) {
+      $row = [];
+      $path = $redirect->getSourcePathWithQuery();
+      $row['path'] = [
+        'class' => ['redirect-table__path'],
+        'data' => ['#plain_text' => $path],
+        'title' => $path,
+      ];
+      $row['operations'] = [
+        'data' => [
+          '#type' => 'operations',
+          '#links' => $list_builder->getOperations($redirect),
+        ],
+      ];
+      $rows[] = $row;
+    }
+    // Add the list to the vertical tabs section of the form.
+    $header = [
+      ['class' => ['redirect-table__path'], 'data' => t('From'),],
+      ['class' => ['redirect-table__operations'], 'data' => t('Operations')],
+    ];
+
+    $form['url_redirects'] = [
+      '#type' => 'details',
+      '#title' => t('URL redirects'),
+      '#group' => 'advanced',
+      '#open' => FALSE,
+      'table' => [
+        '#type' => 'table',
+        '#header' => $header,
+        '#rows' => $rows,
+        '#empty' => t('No URL redirects available.'),
+        '#attributes' => ['class' => ['redirect-table']],
+      ],
+      '#attached' => [
+        'library' => [
+          'redirect/drupal.redirect.admin',
+        ],
+      ],
+    ];
+    if (!empty($rows)) {
+      $form['url_redirects']['warning'] = [
+        '#markup' => t('Note: links open in the current window.'),
+        '#prefix' => '<p>',
+        '#suffix' => '</p>',
+      ];
+    }
+
+    $form['url_redirects']['actions'] = [
+      '#theme' => 'links',
+      '#links' => [],
+      '#attributes' => ['class' => ['action-links']],
+    ];
+    $form['url_redirects']['actions']['#links']['add'] = [
+      'title' => t('Add URL redirect'),
+      'url' => Url::fromRoute('redirect.add', [
+        'redirect' => $group->toUrl()->getInternalPath(),
+        'destination' => \Drupal::destination()->get(),
+      ]),
+      'attributes' => [
+        'class' => [
+          'button',
+        ],
+        'target' => '_blank',
+      ],
+    ];
+
+  }
+}
+

--- a/templates/group-edit-form.html.twig
+++ b/templates/group-edit-form.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Theme override for a group edit form.
+ *
+ * Two column template for the group add/edit form.
+ *
+ * This template will be used when a group edit form specifies 'group_edit_form'
+ * as its #theme callback.  Otherwise, by default, group add/edit forms will be
+ * themed by form.html.twig.
+ *
+ * Available variables:
+ * - form: The group add/edit form.
+ *
+ * @see claro_form_group_form_alter()
+ */
+#}
+<div class="layout-group-form clearfix">
+  <div class="layout-region layout-region--group-main">
+    <div class="layout-region__content">
+      {{ form|without('advanced', 'footer', 'actions') }}
+    </div>
+  </div>
+  <div class="layout-region layout-region--group-secondary">
+    <div class="layout-region__content">
+      {{ form.advanced }}
+    </div>
+  </div>
+  <div class="layout-region layout-region--group-footer">
+    <div class="layout-region__content">
+      <div class="divider"></div>
+      {{ form.footer }}
+      {{ form.actions }}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This commit implements a hook form alter in the osu_groups module, enabling administrators to manage URL redirects within groups. It provides a user-friendly interface in the advanced tab of the group form, showing a table of existing redirects and an 'Add URL redirect' button. This update ensures better management of URL redirects within groups.