### PR TITLE
Update Group Content Author role and refactor code in osu_groups_basi…

### DIFF
--- a/modules/osu_groups_basic_group/config/install/user.role.group_content_author.yml
+++ b/modules/osu_groups_basic_group/config/install/user.role.group_content_author.yml
@@ -1,3 +1,4 @@
+uuid: a152a426-7ab0-445d-95f1-777ffe74ada1
 langcode: en
 status: true
 dependencies:
@@ -13,9 +14,11 @@ dependencies:
   module:
     - contextual
     - dropzonejs
+    - editoria11y
     - filter
     - layout_builder
     - media
+    - system
 id: group_content_author
 label: 'Group Content Author'
 weight: -7
@@ -23,6 +26,7 @@ is_admin: null
 permissions:
   - 'access contextual links'
   - 'access media overview'
+  - 'access site reports'
   - 'configure editable basic_group group layout overrides'
   - 'configure editable page node layout overrides'
   - 'configure editable story node layout overrides'
@@ -40,5 +44,9 @@ permissions:
   - 'edit own image media'
   - 'edit own kaltura media'
   - 'edit own remote_video media'
+  - 'manage editoria11y results'
+  - 'mark as hidden in editoria11y'
+  - 'mark as ok in editoria11y'
   - 'use text format full_html'
   - 'view all media revisions'
+  - 'view editoria11y checker'

--- a/modules/osu_groups_basic_group/osu_groups_basic_group.install
+++ b/modules/osu_groups_basic_group/osu_groups_basic_group.install
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\user\Entity\Role;
@@ -15,7 +16,7 @@ use Drupal\views\Entity\View;
 /**
  * Implements hook_install().
  */
-function osu_groups_basic_group_install($is_syncing) {
+function osu_groups_basic_group_install($is_syncing): void {
   $form_display = \Drupal::entityTypeManager()
     ->getStorage('entity_form_display')
     ->load('node.page.default');
@@ -193,7 +194,7 @@ function _group_admin_permissions(Role $role): void {
 /**
  * Update with new hide_main_navigation field.
  */
-function osu_groups_basic_group_update_9001() {
+function osu_groups_basic_group_update_9001(): void {
   $source = get_module_source_path();
 
   // Obtain the storage manager for field storage bases
@@ -325,7 +326,7 @@ function osu_groups_basic_group_update_9002(&$sandbox) {
 /**
  * Add use_admin_theme to group views.
  */
-function osu_groups_basic_group_update_9003(&$sandbox) {
+function osu_groups_basic_group_update_9003(&$sandbox): TranslatableMarkup {
   $group_nodes_view = View::load('group_nodes');
   $group_nodes_view_display = $group_nodes_view->get('display');
   $group_nodes_view_display['page_1']['display_options']['use_admin_theme'] = TRUE;
@@ -355,7 +356,7 @@ function get_module_source_path(): FileStorage {
 /**
  * Update field label and description for the global nav toggle.
  */
-function osu_groups_basic_group_update_9004(&$sandbox) {
+function osu_groups_basic_group_update_9004(&$sandbox): TranslatableMarkup {
   $config_factory = \Drupal::configFactory();
   $use_toggle_label = $config_factory->getEditable('field.field.group.basic_group.field_hide_global_navigation');
   $use_toggle_label->set('label', 'Use Group Menu');
@@ -384,7 +385,7 @@ function osu_groups_basic_group_update_9006(&$sandbox): void {
 /**
  * Add new roles for Groups.
  */
-function osu_groups_basic_group_update_9007(&$sandbox) {
+function osu_groups_basic_group_update_9007(&$sandbox): void {
   $module_config_path = get_module_source_path();
   /** @var Drupal\group\Entity\Storage\GroupRoleStorage $group_role_storage */
   $group_role_storage = \Drupal::entityTypeManager()->getStorage('group_role');
@@ -404,7 +405,7 @@ function osu_groups_basic_group_update_9007(&$sandbox) {
 /**
  * Implements hook_update_N().
  */
-function osu_groups_basic_group_update_9008(&$sandbox) {
+function osu_groups_basic_group_update_9008(&$sandbox): TranslatableMarkup {
   $module_config_path = get_module_source_path();
 
   // Creating field storages.
@@ -466,7 +467,7 @@ function osu_groups_basic_group_update_9008(&$sandbox) {
 /**
  * Set the new group global setting for auto node title.
  */
-function osu_groups_basic_group_update_9009(&$sandbox) {
+function osu_groups_basic_group_update_9009(&$sandbox): void {
   Drupal::configFactory()
     ->getEditable('group.settings')
     ->set('osu_groups_page_title', TRUE)
@@ -476,7 +477,7 @@ function osu_groups_basic_group_update_9009(&$sandbox) {
 /**
  * Grant 'dropzone upload files' permission to 'group_content_author' role.
  */
-function osu_groups_basic_group_update_9010(&$sandbox) {
+function osu_groups_basic_group_update_9010(&$sandbox): TranslatableMarkup {
   $role_id = 'group_content_author';
   // Check if the role exists before assigning permission to it.
   if ($role = Role::load($role_id)) {
@@ -487,4 +488,18 @@ function osu_groups_basic_group_update_9010(&$sandbox) {
   }
 
   return t('Role %role_id does not exist.', ['%role_id' => $role_id]);
+}
+
+/**
+ * Update OSU Groups Content Author role to allow Editoria11y access.
+ */
+function osu_groups_basic_group_update_10000(&$sandbox): TranslatableMarkup {
+  $role = Role::load('group_content_author');
+  $role->grantPermission('access site reports');
+  $role->grantPermission('manage editoria11y results');
+  $role->grantPermission('mark as hidden in editoria11y');
+  $role->grantPermission('mark as ok in editoria11y');
+  $role->grantPermission('view editoria11y checker');
+  $role->save();
+  return t('Updated OSU Groups Group Content Author role to allow access to Editoria11y.');
 }


### PR DESCRIPTION
…c_group module

This commit introduces updates to the Group Content Author role, which now includes access to the Editoria11y checker and the ability to manage its results. The other changes focused on refactoring code in the osu_groups_basic_group module, mainly by adding return type declarations to functions, and ensuring proper string translation.